### PR TITLE
feat: provide optional boolean 2nd arg to console.keys to get value as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,5 +65,21 @@ A Syncronous method to cause IOS & Android to handle their message loops.
 #### console.keys()
 Prints out all the keys in the object
 
+*Optionally*: You can pass `true` as second argument to also print the value:
+
+```
+var data = {
+  id: 1,
+  name: 'Nathan'
+};
+console.keys(data, true);
+
+// id
+// 1
+// name
+// Nathan
+
+```
+
 ### Breaking Changes
 Renamed Perfomance.now to performance.now -- not sure why I messed up the name in the first place; but the proper name for compatibility sake is "perfomance.now()"...

--- a/master-technology.js
+++ b/master-technology.js
@@ -226,9 +226,10 @@ if (typeof global.console.keys === 'undefined') {
         console.log("=========[ Keys ]==========");
         for(var key in data) {
           if (data.hasOwnProperty(key)) {
-            console.log(key);
             if (printValue) {
-              console.log(data[key]);
+              console.log(key + ':  ', data[key]);
+            } else {
+              console.log(key);
             }
           }
         }

--- a/master-technology.js
+++ b/master-technology.js
@@ -219,13 +219,18 @@ if (!global.process.processMessages) {
 }
 
 if (typeof global.console.keys === 'undefined') {
-    console.keys = function(data) {
+    console.keys = function(data, printValue) {
         if (typeof data === "string") {
             console.log(data); return;
         }
         console.log("=========[ Keys ]==========");
         for(var key in data) {
-            if (data.hasOwnProperty(key)) console.log(key);
+          if (data.hasOwnProperty(key)) {
+            console.log(key);
+            if (printValue) {
+              console.log(data[key]);
+            }
+          }
         }
         console.log("===========================");
     };


### PR DESCRIPTION
I find it very handy sometimes to also get the value when enumerating object keys.
Docs updated:
#### console.keys()

Prints out all the keys in the object

_Optionally_: You can pass `true` as second argument to also print the value:

```
var data = {
  id: 1,
  name: 'Nathan'
};
console.keys(data, true);

// id
// 1
// name
// Nathan

```
